### PR TITLE
Add two-stage flow announcement with feedback collection

### DIFF
--- a/app/assets/javascripts/flow_announcement.js
+++ b/app/assets/javascripts/flow_announcement.js
@@ -2,7 +2,8 @@
 //
 // Shows the #flow-announce modal once per calendar day, per browser. The
 // last-shown date is stored in localStorage; if it isn't today, the popup is
-// revealed on load. Dismissing it (Maybe later / close / backdrop / Esc) or
+// revealed on load. "Maybe later" advances to a second stage asking the user
+// to drop @ian a note; dismissing it (Got it / close / backdrop / Esc) or
 // following "Try it now" records today as seen so it won't reappear until
 // tomorrow. Purely front-end: no controller, model or migration changes.
 
@@ -33,6 +34,18 @@
     modal.classList.add("hidden");
   }
 
+  // Reveal a named stage ([data-flow-stage="..."]) and hide the others.
+  function showStage(modal, name) {
+    var stages = modal.querySelectorAll("[data-flow-stage]");
+    Array.prototype.forEach.call(stages, function (stage) {
+      if (stage.getAttribute("data-flow-stage") === name) {
+        stage.classList.remove("hidden");
+      } else {
+        stage.classList.add("hidden");
+      }
+    });
+  }
+
   function init() {
     var modal = document.getElementById("flow-announce");
     if (!modal) {
@@ -55,8 +68,16 @@
       });
     }
 
-    // "Maybe later" / close button — record as seen and dismiss.
-    var dismissers = modal.querySelectorAll(".flow-later, .flow-close");
+    // "Maybe later" — don't dismiss yet; show the "drop @ian a note" stage.
+    var later = modal.querySelector(".flow-later");
+    if (later) {
+      later.addEventListener("click", function () {
+        showStage(modal, "later");
+      });
+    }
+
+    // Close button and "Got it" — record as seen and dismiss.
+    var dismissers = modal.querySelectorAll(".flow-close, .flow-done");
     Array.prototype.forEach.call(dismissers, function (el) {
       el.addEventListener("click", function () {
         markSeen();

--- a/app/assets/stylesheets/flow_announcement.scss
+++ b/app/assets/stylesheets/flow_announcement.scss
@@ -87,6 +87,10 @@ $flow-line: #e4e8ee;
   }
 }
 
+.flow-announce-stage.hidden {
+  display: none !important;
+}
+
 .flow-announce-body {
   padding: 22px 24px;
 
@@ -94,6 +98,11 @@ $flow-line: #e4e8ee;
     margin: 0 0 12px;
     font-size: 14.5px;
     color: $flow-ink;
+  }
+
+  a {
+    color: $flow-orange-dark;
+    font-weight: 600;
   }
 }
 

--- a/app/views/layouts/themes/38degrees/_flow_announcement.html.erb
+++ b/app/views/layouts/themes/38degrees/_flow_announcement.html.erb
@@ -15,16 +15,26 @@
       <div class="flow-announce-badge">&#10024; New &amp; improved</div>
       <h3 id="flow-announce-title">There's a newer version in Flow</h3>
     </div>
-    <div class="flow-announce-body">
-      <p>This file library now has a newer, improved home inside <b>Flow</b>. All of your files are available in <b>both apps</b>, so nothing moves or disappears &mdash; you can switch any time.</p>
-      <div class="flow-announce-steps">
-        To find it in Flow: open <b>Flow</b> &rarr; select <b>Toolkit</b> &rarr; then <b>Files</b>.
+    <div class="flow-announce-stage" data-flow-stage="intro">
+      <div class="flow-announce-body">
+        <p>This file library now has a newer, improved home inside <b>Flow</b>. All of your files are available in <b>both apps</b>, so nothing moves or disappears &mdash; you can switch any time.</p>
+        <div class="flow-announce-steps">
+          To find it in Flow: open <b>Flow</b> &rarr; select <b>Toolkit</b> &rarr; then <b>Files</b>.
+        </div>
+        <p class="flow-announce-muted">Would you like to try it now, or later?</p>
       </div>
-      <p class="flow-announce-muted">Would you like to try it now, or later?</p>
+      <div class="flow-announce-actions">
+        <button type="button" class="flow-announce-btn flow-announce-btn-later flow-later">Maybe later</button>
+        <button type="button" class="flow-announce-btn flow-announce-btn-now" id="flow-now">Try it now &rarr;</button>
+      </div>
     </div>
-    <div class="flow-announce-actions">
-      <button type="button" class="flow-announce-btn flow-announce-btn-later flow-later">Maybe later</button>
-      <button type="button" class="flow-announce-btn flow-announce-btn-now" id="flow-now">Try it now &rarr;</button>
+    <div class="flow-announce-stage hidden" data-flow-stage="later">
+      <div class="flow-announce-body">
+        <p>Before continuing, please drop <a href="mailto:ian.s@38degrees.org.uk">@ian</a> a note so he knows what's missing in the new version.</p>
+      </div>
+      <div class="flow-announce-actions">
+        <button type="button" class="flow-announce-btn flow-announce-btn-now flow-done">Got it</button>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/layouts/themes/38degrees/_flow_announcement.html.erb
+++ b/app/views/layouts/themes/38degrees/_flow_announcement.html.erb
@@ -30,7 +30,7 @@
     </div>
     <div class="flow-announce-stage hidden" data-flow-stage="later">
       <div class="flow-announce-body">
-        <p>Before continuing, please drop <a href="mailto:ian.s@38degrees.org.uk">@ian</a> a note so he knows what's missing in the new version.</p>
+        <p>Before continuing, please drop <a href="https://38degrees.slack.com/team/U011JEN65PF" target="_blank" rel="noopener">@ian</a> a note so he knows what's missing in the new version.</p>
       </div>
       <div class="flow-announce-actions">
         <button type="button" class="flow-announce-btn flow-announce-btn-now flow-done">Got it</button>

--- a/spec/requests/flow_announcement_spec.rb
+++ b/spec/requests/flow_announcement_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe 'Flow announcement popup' do
       )
       expect( response.body ).to have_css '#flow-now', text: 'Try it now'
     end
+
+    it 'includes a hidden "drop @ian a note" stage shown after Maybe later' do
+      get '/'
+
+      expect( response.body ).to have_css '[data-flow-stage="later"].hidden'
+      expect( response.body ).to have_css(
+        '[data-flow-stage="later"]',
+        text: 'drop @ian a note so he knows what\'s missing in the new version'
+      )
+      expect( response.body ).to have_css '.flow-done', text: 'Got it'
+    end
   end
 
   context 'with the default theme' do


### PR DESCRIPTION
## Summary
Enhanced the flow announcement modal to support a two-stage interaction pattern. Users can now click "Maybe later" to see a second stage requesting feedback before dismissing the announcement.

## Key Changes
- **Multi-stage modal support**: Added `showStage()` function to manage visibility of named stages using `data-flow-stage` attributes
- **Updated interaction flow**: 
  - "Maybe later" now advances to a feedback stage instead of immediately dismissing
  - New "Got it" button on the feedback stage completes the dismissal
  - Close button behavior unchanged
- **Feedback collection**: Second stage prompts users to contact @ian with missing features in the new Flow version
- **Styling**: Added CSS for hidden stage visibility and link styling within the announcement body
- **Tests**: Added spec to verify the hidden feedback stage is present and properly configured

## Implementation Details
- The modal now wraps content in `data-flow-stage` containers to enable stage switching
- The "Maybe later" button listener was separated from the dismissal logic to allow intermediate state handling
- Dismissal logic consolidated under "Got it" button and close button
- All changes are front-end only with no backend modifications required

https://claude.ai/code/session_0199QDwxJi4xDpttPRd1V49N